### PR TITLE
add support edge-chromium

### DIFF
--- a/dist/rtcstats-wrapper.js
+++ b/dist/rtcstats-wrapper.js
@@ -1752,6 +1752,7 @@
 
 	  switch (browser.name) {
 	    case "chrome":
+	    case "edge-chromium":
 	      return ChromeRTCStatsReport;
 	    case "firefox":
 	      return FirefoxRTCStatsReport;

--- a/src/standardize-support.js
+++ b/src/standardize-support.js
@@ -11,6 +11,7 @@ export function getStandardizer() {
 
   switch (browser.name) {
     case "chrome":
+    case "edge-chromium":
       return ChromeRTCStatsReport;
     case "firefox":
       return FirefoxRTCStatsReport;


### PR DESCRIPTION
Currently, On Edge/Chromium , `standardizeReport()` throws this error.

```
rtcstats-wrapper.js:1442 Uncaught (in promise) Error: Received an unknown stats-type string: track.
    at BaseRTCStatsReport._getRTCStatsReference (rtcstats-wrapper.js:1442)
    at new BaseRTCStatsReport (rtcstats-wrapper.js:1309)
    at standardizeReport (rtcstats-wrapper.js:1782)
    at eval (index.js:34)
```

This PR adds Edge/Chromium browser support.