### PR TITLE
Suggestion/ysd 0001

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/dist/rtcstats-wrapper.js
+++ b/dist/rtcstats-wrapper.js
@@ -3127,10 +3127,8 @@
 	    this._intervalID = setInterval(async () => {
 	      const stats = await this._statsSrc.getStats();
 	      this._moment.update(stats);
-
-	      this._checkStatus(this.report);
-
 	      this.onUpdate(this.report);
+	      this._checkStatus(this.report);
 	    }, this._interval);
 	  }
 

--- a/dist/rtcstats-wrapper.js
+++ b/dist/rtcstats-wrapper.js
@@ -1919,7 +1919,7 @@
 	  ) {
 	    // While we only support single-track stream, this method only care about 1 transceiver.
 
-	    // Trace data from above and ignore invalid stats.
+	    // Trace data from above and ignore invalid data.
 	    let RTCVideoReceiverStatsIndex = 0;
 	    const RTCVideoReceiverStatsList = last.get(RTCStatsReferences.RTCVideoReceivers.key);
 	    for (let i = 0; i < RTCVideoReceiverStatsList.length; ++i) {
@@ -1960,7 +1960,7 @@
 	  if (last.has(RTCStatsReferences.RTCInboundRtpVideoStreams.key)) {
 	    // While we only support single-track stream, this method only care about 1 transceiver.
 
-	    // Trace data from above and ignore invalid stats.
+	    // Trace data from above and ignore invalid data.
 	    let RTCInboundRtpVideoStreamStatsIndex = 0;
 	    const RTCInboundRtpVideoStreamStatsList = last.get(RTCStatsReferences.RTCInboundRtpVideoStreams.key);
 	    for (let i = 0; i < RTCInboundRtpVideoStreamStatsList.length; ++i) {

--- a/dist/rtcstats-wrapper.js
+++ b/dist/rtcstats-wrapper.js
@@ -744,7 +744,8 @@
 	  "RTCLocalIceCandidates",
 	  "RTCRemoteIceCandidates",
 	  "RTCCertificates",
-	  "RTCStunServerConnections"
+	  "RTCStunServerConnections",
+	  "Invalid"
 	]);
 
 	const RTCStatsReferenceMap = new Map([
@@ -1272,6 +1273,10 @@
 	      "totalResponsesReceived",
 	      "totalRoundTripTime"
 	    ]
+	  ],
+	  [
+	    RTCStatsReferences.Invalid.key,
+	    []
 	  ]
 	]);
 
@@ -1555,8 +1560,9 @@
 	          return RTCStatsReferences.RTCVideoSenders.key;
 	        } else if (stats.hasOwnProperty("audioLevel")) {
 	          return RTCStatsReferences.RTCAudioSenders.key;
+	        } else {
+	          return RTCStatsReferences.Invalid.key;
 	        }
-	        break;
 	      case "inbound-rtp":
 	        if (stats.mediaType === "video") {
 	          return RTCStatsReferences.RTCInboundRtpVideoStreams.key;

--- a/dist/rtcstats-wrapper.js
+++ b/dist/rtcstats-wrapper.js
@@ -1918,15 +1918,27 @@
 	    prev.has(RTCStatsReferences.RTCVideoReceivers.key)
 	  ) {
 	    // While we only support single-track stream, this method only care about 1 transceiver.
+
+	    // Trace data from above and ignore invalid stats.
+	    let RTCVideoReceiverStatsIndex = 0;
+	    const RTCVideoReceiverStatsList = last.get(RTCStatsReferences.RTCVideoReceivers.key);
+	    for (let i = 0; i < RTCVideoReceiverStatsList.length; ++i) {
+	      const s = RTCVideoReceiverStatsList[i];
+	      if (s.jitterBufferEmittedCount) {
+	        RTCVideoReceiverStatsIndex = i;
+	        break;
+	      }
+	    }
+
 	    const RTCVideoReceiverStats = last.get(
 	      RTCStatsReferences.RTCVideoReceivers.key
-	    )[0];
+	    )[RTCVideoReceiverStatsIndex];
 
 	    if (prev.has(RTCStatsReferences.RTCVideoReceivers.key)) {
 	      const previous = {
 	        RTCVideoReceiverStats: prev.get(
 	          RTCStatsReferences.RTCVideoReceivers.key
-	        )[0]
+	        )[RTCVideoReceiverStatsIndex]
 	      };
 
 	      if (
@@ -1947,9 +1959,21 @@
 
 	  if (last.has(RTCStatsReferences.RTCInboundRtpVideoStreams.key)) {
 	    // While we only support single-track stream, this method only care about 1 transceiver.
+
+	    // Trace data from above and ignore invalid stats.
+	    let RTCInboundRtpVideoStreamStatsIndex = 0;
+	    const RTCInboundRtpVideoStreamStatsList = last.get(RTCStatsReferences.RTCInboundRtpVideoStreams.key);
+	    for (let i = 0; i < RTCInboundRtpVideoStreamStatsList.length; ++i) {
+	      const s = RTCInboundRtpVideoStreamStatsList[i];
+	      if (s.packetsReceived) {
+	        RTCInboundRtpVideoStreamStatsIndex = i;
+	        break;
+	      }
+	    }
+
 	    const RTCInboundRtpVideoStreamStats = last.get(
 	      RTCStatsReferences.RTCInboundRtpVideoStreams.key
-	    )[0];
+	    )[RTCInboundRtpVideoStreamStatsIndex];
 
 	    // calculate fractionLost
 	    if (
@@ -1965,7 +1989,7 @@
 	      const previous = {
 	        RTCInboundRtpVideoStreamStats: prev.get(
 	          RTCStatsReferences.RTCInboundRtpVideoStreams.key
-	        )[0]
+	        )[RTCInboundRtpVideoStreamStatsIndex]
 	      };
 
 	      // calculate QP value
@@ -2886,7 +2910,6 @@
 	      unstable: new Array(this._options.within).fill(null),
 	      critical: new Array(this._options.within).fill(null)
 	    };
-	    this._level = StatusLevels.unknown.key;
 	  }
 
 	  get level() {
@@ -2895,12 +2918,12 @@
 	    }
 
 	    const criticalCount = this._store.critical.filter(Boolean).length;
-	    if (criticalCount > this._options.failCount) {
+	    if (criticalCount >= this._options.failCount) {
 	      return StatusLevels.critical.key;
 	    }
 
-	    const unstableCount = this._store.critical.filter(Boolean).length;
-	    if (unstableCount > this._options.failCount) {
+	    const unstableCount = this._store.unstable.filter(Boolean).length;
+	    if (unstableCount >= this._options.failCount) {
 	      return StatusLevels.unstable.key;
 	    }
 
@@ -2978,6 +3001,15 @@
 	        }),
 	      {}
 	    );
+	    this.onUpdate = options.onUpdate || ((_) => {});
+	  }
+
+	  get status() {
+	    return this._status;
+	  }
+
+	  get report() {
+	    return this._moment.report();
 	  }
 
 	  /**
@@ -3087,11 +3119,12 @@
 	     */
 
 	    this._intervalID = setInterval(async () => {
-	      const report = await this._statsSrc.getStats();
-	      this._moment.update(report);
+	      const stats = await this._statsSrc.getStats();
+	      this._moment.update(stats);
 
-	      const momentum = this._moment.report();
-	      this._checkStatus(momentum);
+	      this._checkStatus(this.report);
+
+	      this.onUpdate(this.report);
 	    }, this._interval);
 	  }
 
@@ -3102,10 +3135,7 @@
 	    clearInterval(this._intervalID);
 	  }
 
-	  get status() {
-	    return this._status;
-	  }
-	  _checkStatus(moment) {
+	  _checkStatus(report) {
 	    const metrics = [
 	      { direction: "send", kind: "audio", key: "rtt" },
 	      { direction: "send", kind: "video", key: "rtt" },
@@ -3121,8 +3151,8 @@
 	    for (const { direction, kind, key } of metrics) {
 	      const stats =
 	        direction === "candidatePair"
-	          ? moment[direction]
-	          : moment[direction][kind];
+	          ? report[direction]
+	          : report[direction][kind];
 	      const eventKey = direction === "candidatePair" ? key : `${kind}-${key}`;
 
 	      if (stats.hasOwnProperty(key)) {

--- a/src/rtcstats-insight.js
+++ b/src/rtcstats-insight.js
@@ -334,10 +334,8 @@ export class RTCStatsInsight extends EventEmitter {
     this._intervalID = setInterval(async () => {
       const stats = await this._statsSrc.getStats();
       this._moment.update(stats);
-
-      this._checkStatus(this.report);
-
       this.onUpdate(this.report);
+      this._checkStatus(this.report);
     }, this._interval);
   }
 

--- a/src/rtcstats-moment.js
+++ b/src/rtcstats-moment.js
@@ -136,15 +136,27 @@ function getVideoReceiverStats(last, prev) {
     prev.has(RTCStatsReferences.RTCVideoReceivers.key)
   ) {
     // While we only support single-track stream, this method only care about 1 transceiver.
+
+    // Trace data from above and ignore invalid data.
+    let RTCVideoReceiverStatsIndex = 0;
+    const RTCVideoReceiverStatsList = last.get(RTCStatsReferences.RTCVideoReceivers.key);
+    for (let i = 0; i < RTCVideoReceiverStatsList.length; ++i) {
+      const s = RTCVideoReceiverStatsList[i];
+      if (s.jitterBufferEmittedCount) {
+        RTCVideoReceiverStatsIndex = i;
+        break;
+      }
+    }
+
     const RTCVideoReceiverStats = last.get(
       RTCStatsReferences.RTCVideoReceivers.key
-    )[0];
+    )[RTCVideoReceiverStatsIndex];
 
     if (prev.has(RTCStatsReferences.RTCVideoReceivers.key)) {
       const previous = {
         RTCVideoReceiverStats: prev.get(
           RTCStatsReferences.RTCVideoReceivers.key
-        )[0]
+        )[RTCVideoReceiverStatsIndex]
       };
 
       if (
@@ -165,9 +177,21 @@ function getVideoReceiverStats(last, prev) {
 
   if (last.has(RTCStatsReferences.RTCInboundRtpVideoStreams.key)) {
     // While we only support single-track stream, this method only care about 1 transceiver.
+
+    // Trace data from above and ignore invalid data.
+    let RTCInboundRtpVideoStreamStatsIndex = 0;
+    const RTCInboundRtpVideoStreamStatsList = last.get(RTCStatsReferences.RTCInboundRtpVideoStreams.key);
+    for (let i = 0; i < RTCInboundRtpVideoStreamStatsList.length; ++i) {
+      const s = RTCInboundRtpVideoStreamStatsList[i];
+      if (s.packetsReceived) {
+        RTCInboundRtpVideoStreamStatsIndex = i;
+        break;
+      }
+    }
+
     const RTCInboundRtpVideoStreamStats = last.get(
       RTCStatsReferences.RTCInboundRtpVideoStreams.key
-    )[0];
+    )[RTCInboundRtpVideoStreamStatsIndex];
 
     // calculate fractionLost
     if (
@@ -183,7 +207,7 @@ function getVideoReceiverStats(last, prev) {
       const previous = {
         RTCInboundRtpVideoStreamStats: prev.get(
           RTCStatsReferences.RTCInboundRtpVideoStreams.key
-        )[0]
+        )[RTCInboundRtpVideoStreamStatsIndex]
       };
 
       // calculate QP value

--- a/src/shared/constatnts.js
+++ b/src/shared/constatnts.js
@@ -79,7 +79,8 @@ export const RTCStatsReferences = new Enum([
   "RTCLocalIceCandidates",
   "RTCRemoteIceCandidates",
   "RTCCertificates",
-  "RTCStunServerConnections"
+  "RTCStunServerConnections",
+  "Invalid"
 ]);
 
 export const RTCStatsReferenceMap = new Map([
@@ -607,5 +608,9 @@ export const RTCStatsReferenceMap = new Map([
       "totalResponsesReceived",
       "totalRoundTripTime"
     ]
+  ],
+  [
+    RTCStatsReferences.Invalid.key,
+    []
   ]
 ]);

--- a/src/standardizers/safari.js
+++ b/src/standardizers/safari.js
@@ -18,8 +18,9 @@ export class SafariRTCStatsReport extends BaseRTCStatsReport {
           return RTCStatsReferences.RTCVideoSenders.key;
         } else if (stats.hasOwnProperty("audioLevel")) {
           return RTCStatsReferences.RTCAudioSenders.key;
+        } else {
+          return RTCStatsReferences.Invalid.key;
         }
-        break;
       case "inbound-rtp":
         if (stats.mediaType === "video") {
           return RTCStatsReferences.RTCInboundRtpVideoStreams.key;


### PR DESCRIPTION
こんにちは。SkyWayを利用している開発者です。
今回プルリクエストさせて頂いた内容は以下です。


# .gitignoreがない
成果物もコミット対象であり、手元でのビルドが必要になったため、node_modulesを無視する設定を加えました。



# 複数本の統計情報に対応していない
SFURoomを用いて接続しています。
そして、chrome://webrtc-internals/よりWebRTC接続の映像に関する統計情報を確認しています。
peer.joinRoomを実行した直後にまず、

* RTCMediaStreamTrack_receiver_(ランダムな1~2桁の数値) (track)
* RTCInboundRTPVideoStream_(ランダムな9桁の数値) (inbound-rtp)

という映像に関する統計情報が表示されます。

次に、このブラウザが他の配信元よりstreamを受け取った際にも、

* RTCMediaStreamTrack_receiver_(また別のランダムな1~2桁の数値) (track)
* RTCInboundRTPVideoStream_(また別のランダムな9桁の数値) (inbound-rtp)

という統計情報が表示されます。

joinRoom直後の統計情報は、streamを受け取った後にも変化がありません。
Roomへの参加直後にはまだ誰もstreamを送信している自分以外の参加者は居ないため、この前者の統計情報は必要ではないと考えています。

そこで、joinRoom直後の統計情報に有効な値が含まれていないことを利用して、jitterBufferEmittedCountやpacketsReceivedが0である統計情報を無視して、次の統計情報を見るような仕様にするという方法で実装してみました。
監視できる統計情報が1本までであるという仕様は変わりませんが、無効な統計情報を弾くことができるかと思います。
(すみません、自分が使用する予定のVideo関連だけですが、、)



# RTCStatsInsightの_levelプロパティが更新されていない
元々levelというgetterがあるため不要かと思たことと、更新されないプロパティが存在して紛らわしいかと思い、削除しました。



# unstableCountを数える配列が間違っている
本来は、

```
this._store.unstable.filter(Boolean).length
```

を数えるべきだが、現状は、

```
this._store.critical.filter(Boolean).length
```

を数えてしまうようになっていたため、修正しました。



# unstableやcriticalに変更する際の判定方法を変更
例えば1回でも閾値を超えたら危険レベルの更新通知をさせたい場合は、optionに、

```
triggerCondition: {
    failCount: 1,
    within: 1,
},
```

と設定しますが、判定方法が、

```
criticalCount > this._options.failCount
// 1 > 1 = 常にfalse
```

と、なっており、絶対に更新通知が発火されない作りとなっていました。
比較演算子を「>=」とすることで、問題を解決しています。



# RTCStatsInsightを利用している時にも、更新毎にmoment.report()の値を参照する仕組みが欲しい
実際の値の変化をconsole.logなどで確認しながら開発したいと思いました。
コンストラクタのoptionに「onUpdate」というプロパティを設け、指定した関数でその時のreportを受け取れるような仕組みを設けてみました。


# その他
※尚、distファイルのビルド及び検証は、nodebrewのstableバージョンである、

* node = v14.15.4
* npm = 6.14.5

にて行い、動作確認しました。


以上です。宜しくお願いします。